### PR TITLE
bug (+fix?) in instaparse/visualize using special characters

### DIFF
--- a/src/clj/instaparse/viz.clj
+++ b/src/clj/instaparse/viz.clj
@@ -27,7 +27,7 @@
                                                      (apply str (first n)
                                                             (when (span n)
                                                               ["\\n" (span n)]))
-                                                     (with-out-str (pr n)))})
+                                                     (str n))})
                  :options options))
       
 (defn- enlive-tree-viz
@@ -39,7 +39,7 @@
                                            (apply str (:tag n)
                                                   (when (span n)
                                                     ["\\n" (span n)]))
-                                           (with-out-str (pr n)))})
+                                           (str n))})
              :options options))
 
 (defn tree-type

--- a/test/cljx/instaparse/viz_test.cljx
+++ b/test/cljx/instaparse/viz_test.cljx
@@ -1,4 +1,5 @@
 (ns instaparse.viz-test
+  (:use clojure.test)
   (:require instaparse.core)
   #+clj (:use instaparse.viz))
 
@@ -30,6 +31,13 @@
               leaf: #'a+'
               " :output-format :hiccup))
 
+(def make-tree-special ;; for testing special chars in node description
+     "simple tree parser"
+     (instaparse.core/parser "tree: node*
+              node: leaf | <'('> node (<'('> node <')'>)* node* <')'>
+              leaf: #'[^()]+'
+              " :output-format :hiccup))
+
 #+clj
 (defn view-test-trees [t]
   (tree-viz (make-tree-e "((a)((a)))(a)"))
@@ -43,3 +51,9 @@
   (tree-viz (make-tree-e ""))
   (Thread/sleep t)
   (tree-viz (make-tree-se "")))
+
+(deftest create_buffered_images
+  (testing "works — returns a java.awt.image.BufferedImage"
+    (is (#'instaparse.viz/hiccup-tree-viz (make-tree-special "((no)(escaping)(needed)(here))") {})))
+  (testing "should be fixed — returns nil, but needs be a java.awt.image.BufferedImage"
+    (is (#'instaparse.viz/hiccup-tree-viz (make-tree-special "((a)(\"string\")(requiring)(escaping))") {}))))


### PR DESCRIPTION
insta/visualize will fail, when a tree-node contains a string with special characters.

It is not a bug in rhizome.viz, since it is able to handle special characters as expected.
The problem is caused by instaparse.viz/hiccup-tree-viz doing some wrong (unnecessary) escaping.

My first commit adds a testcase showing the bug.

My second commit seems to fix it.
However I'm not sure why „(with-out-str (pr n))“ was used originally. So maybe this smal fix has to me unknown side effects and another solution is needed.
