### PR TITLE
Misc bugs preventing Failures from pretty-printing properly

### DIFF
--- a/src/cljs/instaparse/failure.cljs
+++ b/src/cljs/instaparse/failure.cljs
@@ -49,7 +49,7 @@
     (:NOT r)
     (do (print "NOT ")    
       (println (:NOT r))),
-    (instance? java.util.regex.Pattern r)
+    (instance? js/RegExp r)
     (println (print/regexp->str r))
     :else
     (prn r)))

--- a/src/cljs/instaparse/gll.cljs
+++ b/src/cljs/instaparse/gll.cljs
@@ -93,7 +93,14 @@
     :neg (negative-lookahead-parse parser index tramp)
     :ord (ordered-alt-full-parse parser index tramp)))
 
-(defrecord Failure [index reason])  
+(defrecord Failure [index reason])
+
+(extend-protocol IPrintWithWriter
+  instaparse.gll/Failure
+  (-pr-writer [fail writer _]
+    (-write writer (with-out-str
+                     (fail/pprint-failure fail)))))
+
 (defn string->segment
   "Converts a string to a Segment, which has fast subsequencing"
   [s]


### PR DESCRIPTION
`IPrintWithWriter` was not implemented yet on the Failure record, and there was also a stray java class in the instaparse.failure namespace.

After this patch, in a Figwheel REPL I get this when there is an error in the input to a parser:

``` clojure
cljs.user=> (def p (insta/parser "S = 'a'+"))
S = "a"+
cljs.user=> (p "aab")
Parse error at line 1 , column 3 :

aab
  ^
Expected:
"a"
```

But I get this when there is a parse error in a grammar:

``` clojure
cljs.user=> (insta/parser "S")
"Error parsing grammar specification:\nParse error at line 1 , column 2 :\n\nS\n ^\nExpected one of:
\n\"=\"\n\"::=\"\n\":=\"\n\":\"\n\"(*\"\n\n"
```

which isn't especially pretty. I'm not sure if this is just a limitation of the REPL specifically (what happens when it catches a string being thrown), or whether we should rethink how to report these multi-line failures on the cljs end. Any thoughts on that?
