### PR TITLE
Add :require cljs.test in a couple namespaces for consistency and fewer warnings

### DIFF
--- a/test/cljx/instaparse/core_test.cljx
+++ b/test/cljx/instaparse/core_test.cljx
@@ -2,6 +2,7 @@
   #+clj (:refer-clojure :exclude [cat read-string])
   (:require #+clj [clojure.test :refer [deftest are]]
             #+clj [clojure.edn :refer [read-string]]
+            #+cljs [cljs.test :as t]
             #+cljs [cljs.reader :refer [read-string]]
             [instaparse.core :as insta]
             [instaparse.cfg :refer [ebnf]]

--- a/test/cljx/instaparse/repeat_test.cljx
+++ b/test/cljx/instaparse/repeat_test.cljx
@@ -1,5 +1,6 @@
 (ns instaparse.repeat-test
-  (:require #+clj [clojure.test :refer [deftest are]]
+  (:require #+cljs [cljs.test :as t]
+            #+clj [clojure.test :refer [deftest are]]
             [instaparse.core :as insta]
             [instaparse.repeat :as repeat])
   #+cljs (:require-macros [instaparse.repeat-test :refer [text-slurp]]


### PR DESCRIPTION
No longer repeatedly emits `WARNING: Use of undeclared Var cljs.test/do-report at line 37 /home/ubuntu/instaparse-cljs/target/generated/test/cljs/instaparse/repeat_test.cljs`
