### PR TITLE
Fix AutoFlattenSeq and FlattenOnDemandVector printing

### DIFF
--- a/src/cljs/instaparse/auto_flatten_seq.cljs
+++ b/src/cljs/instaparse/auto_flatten_seq.cljs
@@ -79,6 +79,8 @@
 
 (deftype AutoFlattenSeq [^PersistentVector v ^number premix-hashcode ^number hashcode ^number cnt ^boolean dirty
                          ^:unsynchronized-mutable ^ISeq cached-seq]
+  Object
+  (toString [self] (pr-str* (seq self)))
   IHash
   (-hash [self] hashcode)
   ISequential
@@ -139,6 +141,11 @@
       (do
         (set! cached-seq (if dirty (flat-seq v) (seq v)))
         cached-seq))))
+
+(extend-protocol IPrintWithWriter
+  instaparse.auto-flatten-seq/AutoFlattenSeq
+  (-pr-writer [afs writer opts]
+    (-pr-writer (seq afs) writer opts)))
      
 (defn auto-flatten-seq [v]
   (let [v (vec v)
@@ -255,6 +262,11 @@
   (-compare [self that]
     (-compare (get-vec self) that))
   )
+
+(extend-protocol IPrintWithWriter
+  instaparse.auto-flatten-seq/FlattenOnDemandVector
+  (-pr-writer [v writer opts]
+    (-pr-writer (get-vec v) writer opts)))
 
 (defn convert-afs-to-vec [^AutoFlattenSeq afs]
   (cond


### PR DESCRIPTION
Both classes needed a "print-method" (or the equivalent in cljs) and AFS needed a "toString".

Fixes #16.
